### PR TITLE
build: add MPS 2025.1 compatibility

### DIFF
--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -18,6 +18,7 @@ jobs:
           # also adjust the compatibility version range of the MPS plugin
           - "2023.3"
           - "2024.1"
+          - "2025.1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 #      - uses: actions/setup-node@v3

--- a/buildSrc/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/buildSrc/src/main/kotlin/org/modelix/CopyMps.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.exclude
 import java.io.File
@@ -52,6 +53,8 @@ val Project.mpsVersion: String get() {
                     "2023.2" to "2023.2.3",
                     "2023.3" to "2023.3.2",
                     "2024.1" to "2024.1.5",
+                    "2024.3" to "2024.3",
+                    "2025.1" to "2025.1.2",
                 )[it],
             ) { "Unknown MPS version: $it" }
         }
@@ -88,6 +91,60 @@ val excludeMPSLibraries: (ModuleDependency).() -> Unit = {
     exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk7")
     exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     exclude("org.jetbrains", "annotations")
+}
+
+/**
+ * Project-level classpath adjustments for modules whose tests boot MPS via the gradle-intellij-plugin
+ * 1.x. Only needed on MPS 2025.1+ (platform >= 251). Configure the test tasks themselves with
+ * [configureMpsTestTask].
+ */
+fun Project.configureMpsTestClasspath() {
+    if (mpsPlatformVersion < 251) return
+
+    // MPS 2025.1+ loads platform services (e.g. SettingsController) from module descriptors in
+    // lib/modules/*.jar. The 1.x plugin doesn't put these on the test classpath, so add them
+    // explicitly; without them the test application fails to boot. Older MPS has no lib/modules.
+    dependencies.add(
+        "testRuntimeOnly",
+        fileTree(mpsHomeDir).matching { include("lib/modules/*.jar") },
+    )
+
+    // MPS bundles JetBrains' coroutines fork (lib/util-8.jar) whose BuildersKt has
+    // runBlockingWithParallelismCompensation, which the platform calls during boot. The vanilla
+    // kotlinx-coroutines-core pulled in transitively lacks that method, so keep it off the test
+    // runtime classpath and let MPS's bundled coroutines win.
+    configurations.named("testRuntimeClasspath").configure {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+    }
+}
+
+/**
+ * Configures a single test task that boots MPS via the gradle-intellij-plugin 1.x. Pair it with
+ * [configureMpsTestClasspath] on the owning project.
+ */
+fun Test.configureMpsTestTask() {
+    // Use a provider to avoid eagerly resolving the MPS home dir
+    jvmArgumentProviders.add {
+        buildList {
+            // JNA's native libraries live under lib/jna/<arch> in the MPS home. Point the test JVM there
+            // so JNA loads the bundled library instead of trying to unpack one from the classpath.
+            // Older MPS versions (2022.2) ship no lib/jna and keep the natives inside the classpath jar,
+            // so the properties must not be set there — jna.noclasspath would leave JNA with no library.
+            val jnaDir =
+                project.mpsHomeDir
+                    .get()
+                    .asFile
+                    .resolve("lib/jna/${System.getProperty("os.arch")}")
+            if (jnaDir.exists()) {
+                add("-Djna.boot.library.path=${jnaDir.absolutePath}")
+                add("-Djna.noclasspath=true")
+                add("-Djna.nosys=true")
+            }
+
+            add("-Dintellij.platform.load.app.info.from.resources=true")
+        }
+    }
 }
 
 fun Project.copyMps(): File {
@@ -137,6 +194,64 @@ fun Project.copyMps(): File {
                 }
             }
         }
+    }
+
+    // The gradle-intellij-plugin 1.x reads the launch information from product-info.json and injects it into the
+    // forked test JVM. Two pieces of that, meant for launching the real IDE, break the test executor on 2025.1+;
+    // MPS <= 2024.1 ships no product-info.json, so the plugin injects neither and the tests pass. Both are sanitized
+    // here, keeping the file present and valid (it also serves as the PathManager marker).
+    val productInfo = mpsHomeDir.get().asFile.resolve("product-info.json")
+    if (productInfo.exists()) {
+        @Suppress("UNCHECKED_CAST")
+        val json = groovy.json.JsonSlurper().parse(productInfo) as MutableMap<String, Any?>
+        val launches = json["launch"] as? List<*> ?: emptyList<Any?>()
+        for (launch in launches.filterIsInstance<MutableMap<String, Any?>>()) {
+            // resolveIdeHomeVariable assumes every additionalJvmArgument is "key=value" and does split("=")[1],
+            // so an argument without "=" (e.g. -XX:+UseCompressedOops) throws IndexOutOfBoundsException while
+            // configuring the test task. Drop them; OpenedPackages provides the --add-opens the platform needs.
+            if (launch.containsKey("additionalJvmArguments")) {
+                launch["additionalJvmArguments"] = emptyList<String>()
+            }
+            // The plugin passes every line of the referenced .vmoptions file to the JVM verbatim, including the
+            // "#Common IntelliJ Platform options:" comment lines. The launcher treats such a token as the main
+            // class, so the -Djava.system.class.loader=com.intellij.util.lang.PathClassLoader it also sets cannot
+            // be resolved (the -cp argfile after the token is ignored) and the VM aborts during initialization.
+            // Strip comment and blank lines, keeping the real options (heap sizes, GC settings, ...).
+            val vmOptionsPath = (launch["vmOptionsFilePath"] as? String)?.removePrefix("../")
+            val vmOptionsFile = vmOptionsPath?.let { mpsHomeDir.get().asFile.resolve(it) }
+            if (vmOptionsFile != null && vmOptionsFile.exists()) {
+                val kept = vmOptionsFile.readLines().filter { it.isNotBlank() && !it.trimStart().startsWith("#") }
+                vmOptionsFile.writeText(kept.joinToString("\n", postfix = "\n"))
+            }
+        }
+
+        // The Maven MPS distribution declares only a Linux/amd64 launch entry. The plugin refuses to
+        // run on a host whose os.arch has no matching launch entry, which blocks running the IDE tests
+        // locally on e.g. Apple Silicon. Add an entry for the current host (cloned from the existing
+        // one, so it inherits the sanitized fields) when none matches. On CI (Linux/amd64) the entry
+        // already exists, so this is a no-op.
+        val mutableLaunches = launches.filterIsInstance<MutableMap<String, Any?>>()
+        if (mutableLaunches.isNotEmpty()) {
+            val osName = System.getProperty("os.name").lowercase()
+            val currentOs =
+                when {
+                    osName.contains("win") -> "Windows"
+                    osName.contains("mac") || osName.contains("darwin") -> "macOS"
+                    else -> "Linux"
+                }
+            val currentArch = System.getProperty("os.arch")
+            val hasMatch = mutableLaunches.any { it["os"] == currentOs && it["arch"] == currentArch }
+            if (!hasMatch) {
+                @Suppress("UNCHECKED_CAST")
+                val launchList = json["launch"] as MutableList<Any?>
+                val hostLaunch = LinkedHashMap(mutableLaunches.first())
+                hostLaunch["os"] = currentOs
+                hostLaunch["arch"] = currentArch
+                launchList.add(hostLaunch)
+            }
+        }
+
+        productInfo.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json)))
     }
 
     // The build number of a local IDE is expected to contain a product code, otherwise an exception is thrown.

--- a/editor-common-mps/build.gradle.kts
+++ b/editor-common-mps/build.gradle.kts
@@ -56,7 +56,7 @@ kotlin {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/mps-image-editor-server/build.gradle.kts
+++ b/mps-image-editor-server/build.gradle.kts
@@ -33,7 +33,7 @@ intellij {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/projectional-editor-ssr-mps-languages/build.gradle.kts
+++ b/projectional-editor-ssr-mps-languages/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.modelix.configureMpsTestClasspath
+import org.modelix.configureMpsTestTask
 import org.modelix.excludeMPSLibraries
 import org.modelix.mpsHomeDir
 import org.modelix.mpsPluginsDir
@@ -28,6 +30,9 @@ dependencies {
     testImplementation(coreLibs.logback.classic, excludeMPSLibraries)
     modelAdaptersPlugin(libs.modelix.mps.model.adapters.plugin)
 }
+
+// MPS 2025.1+ needs extra platform module jars on the test classpath and MPS's bundled coroutines fork.
+configureMpsTestClasspath()
 
 intellij {
     localPath = mpsHomeDir.map { it.asFile.absolutePath }
@@ -91,11 +96,15 @@ intellij {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {
         enabled = false
+    }
+
+    test {
+        configureMpsTestTask()
     }
 
 //    signPlugin {

--- a/projectional-editor-ssr-mps/build.gradle.kts
+++ b/projectional-editor-ssr-mps/build.gradle.kts
@@ -52,7 +52,7 @@ intellij {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/react-ssr-mps/build.gradle.kts
+++ b/react-ssr-mps/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {


### PR DESCRIPTION
## What

Makes the project build and test against **MPS 2025.1**, while keeping **2024.1 as the default**. Ports the build-infrastructure changes from the recent MPS 2025.1 migration in `modelix.core`.

- **`CopyMps.kt`**: add `2025.1` (and `2024.3`) to the version map; sanitize the `product-info.json` that MPS 2025.1 ships (drop non-`key=value` `additionalJvmArguments` and strip comment lines from the referenced `.vmoptions`, plus add a host launch entry) so the gradle-intellij-plugin 1.x can fork the test JVM on 2025.1; add `configureMpsTestClasspath` / `configureMpsTestTask` helpers (gated to platform `>= 251`) needed to boot MPS tests in-process.
- Raise plugin `untilBuild` from `241.*` to `251.*` in all MPS subprojects.
- Wire the test helpers into `projectional-editor-ssr-mps-languages` (the in-process MPS test harness).
- Add `2025.1` to the MPS compatibility CI matrix.

## Why no source changes

The source-level adapter fixes from the core migration (`getFileSystem` return type, `stepIntoArchive`, `removeChild` null-guard) already ship in **modelix.core 19.1.0**, which this project depends on. All of this project's own MPS Kotlin compiles cleanly against 2025.1 (only deprecation warnings), and the `/mps/` MPS-language project builds without needing any `.mps` migrations.

## Verification

Ran the exact compatibility-workflow build locally for both versions:

| MPS | Build | In-process MPS tests |
|---|---|---|
| 2025.1 | ✅ SUCCESSFUL | 25/25 pass (0 failures/errors/skipped) |
| 2024.1 (default) | ✅ SUCCESSFUL | 25/25 pass — no regression |

## Notes for reviewer

- `build.yaml` / `publish.yml` still pin `-Pmps.version.major=2023.3`; left unchanged since 2025.1 was only requested for the compatibility matrix.
- `2024.3` was added to the version map alongside `2025.1` to mirror core's map; harmless and easy to drop if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)