### PR TITLE
ci: auto-merge Dependabot and Renovate pull requests

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,23 @@
+name: Auto-merge dependency updates
+
+# Enables GitHub's native auto-merge for pull requests opened by Dependabot and
+# Renovate. The PR is squash-merged automatically once all required status
+# checks (configured in the branch protection of `main`) pass.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' }}
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enables GitHub's native auto-merge for dependency-update PRs opened by **Dependabot** and **Renovate**. A new workflow runs on each such PR and calls `gh pr merge --auto --squash`, so the PR merges itself once the required status checks on `main` pass.

## Companion repo settings (already applied)
- `allow_auto_merge` enabled on the repository.
- Required status checks added to `main` branch protection: `build`, `build-mps-plugin (2023.3)`, `build-mps-plugin (2024.1)`, `pre-commit`.

## Notes
- **Squash** is used intentionally: `main` requires signed commits and linear history, so replaying the bots' unsigned commits via rebase would be rejected.
- Renovate already routes major updates through Dependency Dashboard approval, so those won't auto-open/auto-merge.
- Once `build-mps-plugin (2025.1)` runs on `main`, consider adding it to the required-checks set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)